### PR TITLE
わかりづらい手順をDocに反映

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,4 +1,4 @@
-# How to deploy 
+# How to deploy
 
 ## 想定環境
 
@@ -11,6 +11,9 @@
 [こちら](docs/GA.md) を参考に、Google Analytics と BigQuery の設定を完了し、BigQuery の ProjectId, DatasetId、GCP アクセスのための credential の三つを用意してください。また Dummy の EC Site も用意してください
 
 ## 1. パッケージインストール
+
+> [!NOTE]
+> このサンプルコードは東京リージョン(ap-northeast-1)での利用のみを想定しています。デフォルトリージョンを別のリージョンに設定している方は、東京リージョンに設定した上でデプロイしてください。
 
 デプロイに必要なパッケージをインストールします。プロジェクトのルート(package.json が存在するディレクトリ)にて下記実行してください。
 
@@ -26,7 +29,6 @@ npm ci
 aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 ```
 
-
 ## 3. AWS CDK のセットアップ
 
 AWS CDK のセットアップをします。この作業は、AWS アカウントのあるリージョンで初めて AWS CDK を利用する際に必要になります。数分程度で完了します
@@ -35,7 +37,6 @@ AWS CDK のセットアップをします。この作業は、AWS アカウン�
 npm run cdk bootstrap
 ```
 
-
 ## 4. AWS CDK の パラメータ設定
 
 [cdk.json](../cdk.json)を開き、下記を設定してください
@@ -43,58 +44,55 @@ npm run cdk bootstrap
 - bqProjectId: BigQuery の Project Id
 - bqDatasetId: BigQuery の Dataset Id
 
-
-
 ## 5. AWS CDK deploy
+
 下記コマンドにて CDK スタックのデプロイを行います
 
 ```bash
 npm run cdk -- deploy --require-approval never
 ```
 
-
 ## 6. BigQuery へのアクセスのための credential 設定
 
-[AWS Secrets Managerのマネジメントコンソール](https://ap-northeast-1.console.aws.amazon.com/secretsmanager/listsecrets?region=ap-northeast-1)を開き、`GAImportGcpSecret`で始まる名前の Secret を開いて、`credentials` キーに GCP のクレデンシャルの文字列を設定してください。下記のような形になります
+[AWS Secrets Manager のマネジメントコンソール](https://ap-northeast-1.console.aws.amazon.com/secretsmanager/listsecrets?region=ap-northeast-1)を開き、`GAImportGcpSecret`で始まる名前の Secret を開いて、`credentials` キーに GCP のクレデンシャルの文字列が設定されるよう。シークレットの値からプレーンテキストを下記のフォーマットで置き換えてください
 
 ```json
-{"credentials": "xxxxxxxxx"}
+{ "credentials": "{GCPのクレデンシャル}" }
 ```
 
+## 7. Amazon Aurora Database 　への接続情報確認
 
-## 7. Amazon Aurora Database　への接続情報確認
-
-同じく AWS Secrets Manager のマネジメントコンソールで、`DatabaseAuroraClusterSecret`で始まる名前の Secret を開くと DBの接続情報を取得可能です。こちらを別タブなどで開いた状態にしてください
+同じく AWS Secrets Manager のマネジメントコンソールで、`DatabaseAuroraClusterSecret`で始まる名前の Secret を開くと DB の接続情報を取得可能です。こちらを別タブなどで開いた状態にしてください
 
 ## 8. Amazon Aurora Database setup
 
-* [Amazon EC2 のマネジメントコンソール](https://ap-northeast-1.console.aws.amazon.com/ec2/home?region=ap-northeast-1#Instances:instanceState=running)を開き、BastionHost のインスタンスのチェックボックスにチェックをいれ、`Connect` をクリックしてください
-`Session Manager` タブを開いて、`Connect` をクリックしてください。
-BastionHost(踏み台) のターミナルを開くことができます。
+- [Amazon EC2 のマネジメントコンソール](https://ap-northeast-1.console.aws.amazon.com/ec2/home?region=ap-northeast-1#Instances:instanceState=running)を開き、BastionHost のインスタンスのチェックボックスにチェックをいれ、`Connect` をクリックしてください
+  `Session Manager` タブを開いて、`Connect` をクリックしてください。
+  BastionHost(踏み台) のターミナルを開くことができます。
 
-* Terminal で下記コマンドを実行し、ec2-user になります
+- Terminal で下記コマンドを実行し、ec2-user になります
 
 ```
 sudo su - ec2-user
 ```
 
-* vim などのエディタで create_tables.sql というテキストを作成し[create_tables.sql](../dbsetup/aurora/create_tables.sql) の内容をコピーしてください
+- vim などのエディタで create_tables.sql というテキストを作成し[create_tables.sql](../dbsetup/aurora/create_tables.sql) の内容をコピーしてください
 
 ```sh
 vim create_tables.sql
 ```
 
-* 下記のように psql で create_tables.sql を実行してください。<DBのhost>および 実行時に聞かれる password は前のセクションで確認した DB 接続情報をコピーしてください。
+- 下記のように psql で create_tables.sql を実行してください。<DB の host>および 実行時に聞かれる password は前のセクションで確認した DB 接続情報をコピーしてください。
 
 ```sh
-psql -h <DBのhost> prototype portgres -f create_tables.sql
+psql -h <DBのhost> prototype postgres -f create_tables.sql
 ```
 
 ## 9. Redshift Database setup
 
-[Amazon Redshift Serverless Query editor v2](https://ap-northeast-1.console.aws.amazon.com/sqlworkbench/home?region=ap-northeast-1#/client)を開き、`ecsample` にて [DDL](../dbsetup/rss/create_tables.sql) を実行してください
+[Amazon Redshift Serverless Query editor v2](https://ap-northeast-1.console.aws.amazon.com/sqlworkbench/home?region=ap-northeast-1#/client)を開き、スキーマを `ecsample` に変更した上で [DDL](../dbsetup/rss/create_tables.sql) を実行してください
 
+> [!IMPORTANT]
+> 左ペインで `ecssample` 内にテーブルが作成されていることを確認してください
 
 これでデプロイは完了です。[こちら](./TEST.md)を参考にテストしてください
-
-

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -60,29 +60,29 @@ npm run cdk -- deploy --require-approval never
 { "credentials": "{GCPのクレデンシャル}" }
 ```
 
-## 7. Amazon Aurora Database 　への接続情報確認
+## 7. Amazon Aurora Database への接続情報確認
 
 同じく AWS Secrets Manager のマネジメントコンソールで、`DatabaseAuroraClusterSecret`で始まる名前の Secret を開くと DB の接続情報を取得可能です。こちらを別タブなどで開いた状態にしてください
 
 ## 8. Amazon Aurora Database setup
 
-- [Amazon EC2 のマネジメントコンソール](https://ap-northeast-1.console.aws.amazon.com/ec2/home?region=ap-northeast-1#Instances:instanceState=running)を開き、BastionHost のインスタンスのチェックボックスにチェックをいれ、`Connect` をクリックしてください
+* [Amazon EC2 のマネジメントコンソール](https://ap-northeast-1.console.aws.amazon.com/ec2/home?region=ap-northeast-1#Instances:instanceState=running)を開き、BastionHost のインスタンスのチェックボックスにチェックをいれ、`Connect` をクリックしてください
   `Session Manager` タブを開いて、`Connect` をクリックしてください。
   BastionHost(踏み台) のターミナルを開くことができます。
 
-- Terminal で下記コマンドを実行し、ec2-user になります
+* Terminal で下記コマンドを実行し、ec2-user になります
 
 ```
 sudo su - ec2-user
 ```
 
-- vim などのエディタで create_tables.sql というテキストを作成し[create_tables.sql](../dbsetup/aurora/create_tables.sql) の内容をコピーしてください
+* vim などのエディタで create_tables.sql というテキストを作成し[create_tables.sql](../dbsetup/aurora/create_tables.sql) の内容をコピーしてください
 
 ```sh
 vim create_tables.sql
 ```
 
-- 下記のように psql で create_tables.sql を実行してください。<DB の host>および 実行時に聞かれる password は前のセクションで確認した DB 接続情報をコピーしてください。
+* 下記のように psql で create_tables.sql を実行してください。<DBのhost>および 実行時に聞かれる password は前のセクションで確認した DB 接続情報をコピーしてください。
 
 ```sh
 psql -h <DBのhost> prototype postgres -f create_tables.sql

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -2,13 +2,13 @@
 
 ## 1. テストデータの生成と投入
 
-- BastionHost(踏み台) にて[テストデータ生成スクリプト](../test/gen_auroratestdata.py)を実行してください
+* BastionHost(踏み台) にて[テストデータ生成スクリプト](../test/gen_auroratestdata.py)を実行してください
 
 ```bash
 python3 gen_auroratestdata.py
 ```
 
-- [テストデータ投入スクリプト](../test/insert_dummy.sh) を編集し、<DBHOST> を実際の Amazon Aurora の Host に設定してから実行してください
+* [テストデータ投入スクリプト](../test/insert_dummy.sh) を編集し、<DBHOST> を実際の Amazon Aurora の Host に設定してから実行してください
 
 ```bash
 bash insert_dummy.sh
@@ -18,7 +18,7 @@ bash insert_dummy.sh
 
 ## 2. Dummy の EC site へアクセス
 
-[こちら](./GA.md)でデプロイした Dummy の EC サイトへ任意のブラウザでアクセスし、アイテムを閲覧してください。この際、 URL の QueryString に`uid=<任意のUserId>` を付与することで、Google Analytics にその UserId の行動として記録されます。Amazon Personalize では学習のために最低 25 人のユーザが必要であるため、25 人分以上のユーザの行動を実施してください。また全体で 1000 イベント必要です。UserId の値は任意ですが、データベースの user_master テーブルにある user_id と合致させる必要があります
+[こちら](./GA.md)でデプロイした Dummy の EC サイトへ任意のブラウザでアクセスし、アイテムを閲覧してください。この際、 URL の QueryString に`uid=<任意のUserId>` を付与することで、Google Analytics にその UserId の行動として記録されます。Amazon Personalize では**学習のために最低25人のユーザが必要であるため、25人分以上のユーザの行動を実施してください。また全体で 1000 イベント必要です**。UserId の値は任意ですが、データベースの user_master テーブルにある user_id と合致させる必要があります
 
 ## 3. Google Analytics および BigQuery での記録を確認
 

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -1,32 +1,28 @@
-# Test 
-
+# Test
 
 ## 1. テストデータの生成と投入
 
-* BastionHost(踏み台) にて[テストデータ生成スクリプト](../test/gen_auroratestdata.py)を実行してください
+- BastionHost(踏み台) にて[テストデータ生成スクリプト](../test/gen_auroratestdata.py)を実行してください
 
-``` bash
+```bash
 python3 gen_auroratestdata.py
 ```
 
-* [テストデータ投入スクリプト](../test/insert_dummy.sh) を編集し、<DBHOST> を実際の Amazon Aurora の Host に設定してから実行してください
+- [テストデータ投入スクリプト](../test/insert_dummy.sh) を編集し、<DBHOST> を実際の Amazon Aurora の Host に設定してから実行してください
 
-``` bash
+```bash
 bash insert_dummy.sh
 ```
 
 ※ 実行までに .pgpass をあらかじめ作成しておくと Amazon Aurora の認証 がスムースです
 
-
 ## 2. Dummy の EC site へアクセス
 
-[こちら](./GA.md)でデプロイした Dummy の EC サイトへ任意のブラウザでアクセスし、アイテムを閲覧してください。この際、 URL の QueryString に`uid=<任意のUserId>` を付与することで、Google Analytics にその UserId の行動として記録されます。Amazon Personalize では学習のために最低25人のユーザが必要であるため、25人分以上のユーザの行動を実施してください。また全体で1000イベント必要です。UserId の値は任意ですが、データベースの user_master テーブルにある user_id と合致させる必要があります
-
+[こちら](./GA.md)でデプロイした Dummy の EC サイトへ任意のブラウザでアクセスし、アイテムを閲覧してください。この際、 URL の QueryString に`uid=<任意のUserId>` を付与することで、Google Analytics にその UserId の行動として記録されます。Amazon Personalize では学習のために最低 25 人のユーザが必要であるため、25 人分以上のユーザの行動を実施してください。また全体で 1000 イベント必要です。UserId の値は任意ですが、データベースの user_master テーブルにある user_id と合致させる必要があります
 
 ## 3. Google Analytics および BigQuery での記録を確認
 
 Google Analytics でユーザの行動が記録されることを確認してください。問題なければ翌日まで待ち、BigQuery に データが格納されていることを確認してください
-
 
 ## 4. ワークフローの実行
 
@@ -37,13 +33,14 @@ Google Analytics でユーザの行動が記録されることを確認してく
 - Amazon Personalize にて Amazon Redshift のデータを使って学習し、Recommender を作成します
 - Amazon Pinpoint にて Amazon Redshift のユーザデータをセグメントとしてインポートします
 
+日付指定で実行する場合は、[注意点](NOTE.md#対象日付を指定しての実行方法)の記述に従って Lambda にパラメータを投入してください。
 
 ## 5. Amazon Personalize でレコメンドの実行
 
 例えば AWS CLI を用いて下記のように実行可能です
 
-``` bash
-aws personalize-runtime get-recommendations --recommender-arn <recommenderのarn>  --user-id <user_id> --item-id <item_id>  
+```bash
+aws personalize-runtime get-recommendations --recommender-arn <recommenderのarn>  --user-id <user_id> --item-id <item_id>
 ```
 
 ## 6. Amazon Pinpoint でセグメント編集とキャンペーン実行


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- ap-northest-1 以外のリージョンにデプロイするとS3バケットのクロスリージョンアクセスが発生してエラーになるためのDocに追加
- Secret Manager上でKey-Valueが初期状態では設定されておらず、`{"credential" : "foobar"}` の形で全体を入力する必要がある点を補足
- Redshift Serveless Query Editor V2の操作について補足
- typoやTrailingspaceの修正

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
